### PR TITLE
[FLINK-11813] Moves JobResultStore initialization further up the call hierarchy

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherGatewayServiceFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherGatewayServiceFactory.java
@@ -29,8 +29,10 @@ import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServicesWithJobGraphStore;
 import org.apache.flink.runtime.dispatcher.runner.AbstractDispatcherLeaderProcess;
 import org.apache.flink.runtime.dispatcher.runner.DefaultDispatcherGatewayService;
+import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphWriter;
+import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -83,7 +85,9 @@ public class ApplicationDispatcherGatewayServiceFactory
     public AbstractDispatcherLeaderProcess.DispatcherGatewayService create(
             DispatcherId fencingToken,
             Collection<JobGraph> recoveredJobs,
-            JobGraphWriter jobGraphWriter) {
+            Collection<JobResult> globallyTerminatedJobs,
+            JobGraphWriter jobGraphWriter,
+            JobResultStore jobResultStore) {
 
         final List<JobID> recoveredJobIds = getRecoveredJobIds(recoveredJobs);
 

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherGatewayServiceFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherGatewayServiceFactory.java
@@ -98,6 +98,7 @@ public class ApplicationDispatcherGatewayServiceFactory
                             rpcService,
                             fencingToken,
                             recoveredJobs,
+                            globallyTerminatedJobs,
                             (dispatcherGateway, scheduledExecutor, errorHandler) ->
                                     new ApplicationDispatcherBootstrap(
                                             application,
@@ -107,7 +108,7 @@ public class ApplicationDispatcherGatewayServiceFactory
                                             scheduledExecutor,
                                             errorHandler),
                             PartialDispatcherServicesWithJobGraphStore.from(
-                                    partialDispatcherServices, jobGraphWriter));
+                                    partialDispatcherServices, jobGraphWriter, jobResultStore));
         } catch (Exception e) {
             throw new FlinkRuntimeException("Could not create the Dispatcher rpc endpoint.", e);
         }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherGatewayServiceFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherGatewayServiceFactory.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.dispatcher.DispatcherFactory;
 import org.apache.flink.runtime.dispatcher.DispatcherId;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
-import org.apache.flink.runtime.dispatcher.PartialDispatcherServicesWithJobGraphStore;
+import org.apache.flink.runtime.dispatcher.PartialDispatcherServicesWithJobPersistenceComponents;
 import org.apache.flink.runtime.dispatcher.runner.AbstractDispatcherLeaderProcess;
 import org.apache.flink.runtime.dispatcher.runner.DefaultDispatcherGatewayService;
 import org.apache.flink.runtime.highavailability.JobResultStore;
@@ -107,7 +107,7 @@ public class ApplicationDispatcherGatewayServiceFactory
                                             dispatcherGateway,
                                             scheduledExecutor,
                                             errorHandler),
-                            PartialDispatcherServicesWithJobGraphStore.from(
+                            PartialDispatcherServicesWithJobPersistenceComponents.from(
                                     partialDispatcherServices, jobGraphWriter, jobResultStore));
         } catch (Exception e) {
             throw new FlinkRuntimeException("Could not create the Dispatcher rpc endpoint.", e);

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherLeaderProcessFactoryFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherLeaderProcessFactoryFactory.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
 import org.apache.flink.runtime.dispatcher.runner.DispatcherLeaderProcessFactory;
 import org.apache.flink.runtime.dispatcher.runner.DispatcherLeaderProcessFactoryFactory;
 import org.apache.flink.runtime.dispatcher.runner.SessionDispatcherLeaderProcessFactory;
-import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
+import org.apache.flink.runtime.jobmanager.JobPersistenceComponentFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 
@@ -59,7 +59,7 @@ public class ApplicationDispatcherLeaderProcessFactoryFactory
 
     @Override
     public DispatcherLeaderProcessFactory createFactory(
-            JobGraphStoreFactory jobGraphStoreFactory,
+            JobPersistenceComponentFactory jobPersistenceComponentFactory,
             Executor ioExecutor,
             RpcService rpcService,
             PartialDispatcherServices partialDispatcherServices,
@@ -74,7 +74,10 @@ public class ApplicationDispatcherLeaderProcessFactoryFactory
                         partialDispatcherServices);
 
         return new SessionDispatcherLeaderProcessFactory(
-                dispatcherServiceFactory, jobGraphStoreFactory, ioExecutor, fatalErrorHandler);
+                dispatcherServiceFactory,
+                jobPersistenceComponentFactory,
+                ioExecutor,
+                fatalErrorHandler);
     }
 
     public static ApplicationDispatcherLeaderProcessFactoryFactory create(

--- a/flink-core/src/main/java/org/apache/flink/util/function/QuintFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/QuintFunction.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.function;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Function which takes three arguments.
+ *
+ * @param <S> type of the first argument
+ * @param <T> type of the second argument
+ * @param <U> type of the third argument
+ * @param <V> type of the fourth argument
+ * @param <W> type of the fifth argument
+ * @param <R> type of the return value
+ */
+@PublicEvolving
+@FunctionalInterface
+public interface QuintFunction<S, T, U, V, W, R> {
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param s the first function argument
+     * @param t the second function argument
+     * @param u the third function argument
+     * @param v the fourth function argument
+     * @param w the fifth function argument
+     * @return the function result
+     */
+    R apply(S s, T t, U u, V v, W w);
+}

--- a/flink-core/src/main/java/org/apache/flink/util/function/QuintFunctionWithException.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/QuintFunctionWithException.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.function;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.ExceptionUtils;
+
+/**
+ * Function which takes five arguments.
+ *
+ * @param <S> type of the first argument
+ * @param <T> type of the second argument
+ * @param <U> type of the third argument
+ * @param <V> type of the four argument
+ * @param <W> type of the five argument
+ * @param <R> type of the return value
+ * @param <E> type of the thrown exception
+ */
+@PublicEvolving
+@FunctionalInterface
+public interface QuintFunctionWithException<S, T, U, V, W, R, E extends Throwable> {
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param s the first function argument
+     * @param t the second function argument
+     * @param u the third function argument
+     * @param v the four function argument
+     * @param w the five function argument
+     * @return the function result
+     * @throws E if it fails
+     */
+    R apply(S s, T t, U u, V v, W w) throws E;
+
+    /**
+     * Convert at {@link QuintFunctionWithException} into a {@link QuintFunction}.
+     *
+     * @param quintFunctionWithException function with exception to convert into a function
+     * @param <A> first input type
+     * @param <B> second input type
+     * @param <C> third input type
+     * @param <D> fourth input type
+     * @param <E> fifth input type
+     * @param <R> output type
+     * @return {@link QuintFunction} which throws all checked exception as an unchecked exception.
+     */
+    static <A, B, C, D, E, R> QuintFunction<A, B, C, D, E, R> unchecked(
+            QuintFunctionWithException<A, B, C, D, E, R, ?> quintFunctionWithException) {
+        return (A a, B b, C c, D d, E e) -> {
+            try {
+                return quintFunctionWithException.apply(a, b, c, d, e);
+            } catch (Throwable t) {
+                ExceptionUtils.rethrow(t);
+                // we need this to appease the compiler :-(
+                return null;
+            }
+        };
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -846,7 +846,8 @@ public class BlobServer extends Thread
             try {
                 FileUtils.deleteDirectory(jobDir);
 
-                // NOTE: Instead of going through blobExpiryTimes, keep lingering entries - they
+                // NOTE on why blobExpiryTimes are not cleaned up:
+                //       Instead of going through blobExpiryTimes, keep lingering entries - they
                 //       will be cleaned up by the timer task which tolerates non-existing files
                 //       If inserted again with the same IDs (via put()), the TTL will be updated
                 //       again.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -122,6 +122,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 
     private final Collection<JobGraph> recoveredJobs;
 
+    private final Collection<JobResult> globallyTerminatedJobs;
+
     private final DispatcherBootstrapFactory dispatcherBootstrapFactory;
 
     private final ExecutionGraphInfoStore executionGraphInfoStore;
@@ -154,6 +156,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
             RpcService rpcService,
             DispatcherId fencingToken,
             Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> globallyTerminatedJobs,
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
             DispatcherServices dispatcherServices)
             throws Exception {
@@ -192,6 +195,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
         this.dispatcherBootstrapFactory = checkNotNull(dispatcherBootstrapFactory);
 
         this.recoveredJobs = new HashSet<>(recoveredJobs);
+
+        this.globallyTerminatedJobs = new HashSet<>(globallyTerminatedJobs);
 
         this.dispatcherCachedOperationsHandler =
                 new DispatcherCachedOperationsHandler(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -168,6 +168,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
         this.blobServer = dispatcherServices.getBlobServer();
         this.fatalErrorHandler = dispatcherServices.getFatalErrorHandler();
         this.jobGraphWriter = dispatcherServices.getJobGraphWriter();
+        this.jobResultStore = dispatcherServices.getJobResultStore();
         this.jobManagerMetricGroup = dispatcherServices.getJobManagerMetricGroup();
         this.metricServiceQueryAddress = dispatcherServices.getMetricQueryServiceAddress();
         this.ioExecutor = dispatcherServices.getIoExecutor();
@@ -175,8 +176,6 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
         this.jobManagerSharedServices =
                 JobManagerSharedServices.fromConfiguration(
                         configuration, blobServer, fatalErrorHandler);
-
-        this.jobResultStore = highAvailabilityServices.getJobResultStore();
 
         runningJobs = new HashMap<>(16);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rpc.RpcService;
 
 import java.util.Collection;
@@ -31,6 +32,7 @@ public interface DispatcherFactory {
             RpcService rpcService,
             DispatcherId fencingToken,
             Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> globallyTerminatedJobs,
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
             PartialDispatcherServicesWithJobGraphStore partialDispatcherServicesWithJobGraphStore)
             throws Exception;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherFactory.java
@@ -34,6 +34,7 @@ public interface DispatcherFactory {
             Collection<JobGraph> recoveredJobs,
             Collection<JobResult> globallyTerminatedJobs,
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
-            PartialDispatcherServicesWithJobGraphStore partialDispatcherServicesWithJobGraphStore)
+            PartialDispatcherServicesWithJobPersistenceComponents
+                    partialDispatcherServicesWithJobPersistenceComponents)
             throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
@@ -27,8 +27,8 @@ import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.Preconditions;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.concurrent.Executor;
@@ -36,106 +36,104 @@ import java.util.concurrent.Executor;
 /** {@link Dispatcher} services container. */
 public class DispatcherServices {
 
-    @Nonnull private final Configuration configuration;
+    private final Configuration configuration;
 
-    @Nonnull private final HighAvailabilityServices highAvailabilityServices;
+    private final HighAvailabilityServices highAvailabilityServices;
 
-    @Nonnull private final GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever;
+    private final GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever;
 
-    @Nonnull private final BlobServer blobServer;
+    private final BlobServer blobServer;
 
-    @Nonnull private final HeartbeatServices heartbeatServices;
+    private final HeartbeatServices heartbeatServices;
 
-    @Nonnull private final JobManagerMetricGroup jobManagerMetricGroup;
+    private final JobManagerMetricGroup jobManagerMetricGroup;
 
-    @Nonnull private final ExecutionGraphInfoStore executionGraphInfoStore;
+    private final ExecutionGraphInfoStore executionGraphInfoStore;
 
-    @Nonnull private final FatalErrorHandler fatalErrorHandler;
+    private final FatalErrorHandler fatalErrorHandler;
 
-    @Nonnull private final HistoryServerArchivist historyServerArchivist;
+    private final HistoryServerArchivist historyServerArchivist;
 
     @Nullable private final String metricQueryServiceAddress;
 
-    @Nonnull private final DispatcherOperationCaches operationCaches;
+    private final DispatcherOperationCaches operationCaches;
 
-    @Nonnull private final JobGraphWriter jobGraphWriter;
+    private final JobGraphWriter jobGraphWriter;
 
-    @Nonnull private final JobManagerRunnerFactory jobManagerRunnerFactory;
+    private final JobManagerRunnerFactory jobManagerRunnerFactory;
 
-    @Nonnull private final Executor ioExecutor;
+    private final Executor ioExecutor;
 
     DispatcherServices(
-            @Nonnull Configuration configuration,
-            @Nonnull HighAvailabilityServices highAvailabilityServices,
-            @Nonnull GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
-            @Nonnull BlobServer blobServer,
-            @Nonnull HeartbeatServices heartbeatServices,
-            @Nonnull ExecutionGraphInfoStore executionGraphInfoStore,
-            @Nonnull FatalErrorHandler fatalErrorHandler,
-            @Nonnull HistoryServerArchivist historyServerArchivist,
+            Configuration configuration,
+            HighAvailabilityServices highAvailabilityServices,
+            GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
+            BlobServer blobServer,
+            HeartbeatServices heartbeatServices,
+            ExecutionGraphInfoStore executionGraphInfoStore,
+            FatalErrorHandler fatalErrorHandler,
+            HistoryServerArchivist historyServerArchivist,
             @Nullable String metricQueryServiceAddress,
-            @Nonnull DispatcherOperationCaches operationCaches,
-            @Nonnull JobManagerMetricGroup jobManagerMetricGroup,
-            @Nonnull JobGraphWriter jobGraphWriter,
-            @Nonnull JobManagerRunnerFactory jobManagerRunnerFactory,
-            @Nonnull Executor ioExecutor) {
-        this.configuration = configuration;
-        this.highAvailabilityServices = highAvailabilityServices;
-        this.resourceManagerGatewayRetriever = resourceManagerGatewayRetriever;
-        this.blobServer = blobServer;
-        this.heartbeatServices = heartbeatServices;
-        this.executionGraphInfoStore = executionGraphInfoStore;
-        this.fatalErrorHandler = fatalErrorHandler;
-        this.historyServerArchivist = historyServerArchivist;
+            DispatcherOperationCaches operationCaches,
+            JobManagerMetricGroup jobManagerMetricGroup,
+            JobGraphWriter jobGraphWriter,
+            JobManagerRunnerFactory jobManagerRunnerFactory,
+            Executor ioExecutor) {
+        this.configuration = Preconditions.checkNotNull(configuration, "Configuration");
+        this.highAvailabilityServices =
+                Preconditions.checkNotNull(highAvailabilityServices, "HighAvailabilityServices");
+        this.resourceManagerGatewayRetriever =
+                Preconditions.checkNotNull(
+                        resourceManagerGatewayRetriever, "ResourceManagerGatewayRetriever");
+        this.blobServer = Preconditions.checkNotNull(blobServer, "BlobServer");
+        this.heartbeatServices = Preconditions.checkNotNull(heartbeatServices, "HeartBeatServices");
+        this.executionGraphInfoStore =
+                Preconditions.checkNotNull(executionGraphInfoStore, "ExecutionGraphInfoStore");
+        this.fatalErrorHandler = Preconditions.checkNotNull(fatalErrorHandler, "FatalErrorHandler");
+        this.historyServerArchivist =
+                Preconditions.checkNotNull(historyServerArchivist, "HistoryServerArchivist");
         this.metricQueryServiceAddress = metricQueryServiceAddress;
-        this.operationCaches = operationCaches;
-        this.jobManagerMetricGroup = jobManagerMetricGroup;
-        this.jobGraphWriter = jobGraphWriter;
-        this.jobManagerRunnerFactory = jobManagerRunnerFactory;
-        this.ioExecutor = ioExecutor;
+        this.operationCaches = Preconditions.checkNotNull(operationCaches, "OperationCaches");
+        this.jobManagerMetricGroup =
+                Preconditions.checkNotNull(jobManagerMetricGroup, "JobManagerMetricGroup");
+        this.jobGraphWriter = Preconditions.checkNotNull(jobGraphWriter, "JobGraphWriter");
+        this.jobManagerRunnerFactory =
+                Preconditions.checkNotNull(jobManagerRunnerFactory, "JobManagerRunnerFactory");
+        this.ioExecutor = Preconditions.checkNotNull(ioExecutor, "IOExecutor");
     }
 
-    @Nonnull
     public Configuration getConfiguration() {
         return configuration;
     }
 
-    @Nonnull
     public HighAvailabilityServices getHighAvailabilityServices() {
         return highAvailabilityServices;
     }
 
-    @Nonnull
     public GatewayRetriever<ResourceManagerGateway> getResourceManagerGatewayRetriever() {
         return resourceManagerGatewayRetriever;
     }
 
-    @Nonnull
     public BlobServer getBlobServer() {
         return blobServer;
     }
 
-    @Nonnull
     public HeartbeatServices getHeartbeatServices() {
         return heartbeatServices;
     }
 
-    @Nonnull
     public JobManagerMetricGroup getJobManagerMetricGroup() {
         return jobManagerMetricGroup;
     }
 
-    @Nonnull
     public ExecutionGraphInfoStore getArchivedExecutionGraphStore() {
         return executionGraphInfoStore;
     }
 
-    @Nonnull
     public FatalErrorHandler getFatalErrorHandler() {
         return fatalErrorHandler;
     }
 
-    @Nonnull
     public HistoryServerArchivist getHistoryServerArchivist() {
         return historyServerArchivist;
     }
@@ -145,31 +143,26 @@ public class DispatcherServices {
         return metricQueryServiceAddress;
     }
 
-    @Nonnull
     public DispatcherOperationCaches getOperationCaches() {
         return operationCaches;
     }
 
-    @Nonnull
     public JobGraphWriter getJobGraphWriter() {
         return jobGraphWriter;
     }
 
-    @Nonnull
     JobManagerRunnerFactory getJobManagerRunnerFactory() {
         return jobManagerRunnerFactory;
     }
 
-    @Nonnull
     public Executor getIoExecutor() {
         return ioExecutor;
     }
 
     public static DispatcherServices from(
-            @Nonnull
-                    PartialDispatcherServicesWithJobPersistenceComponents
-                            partialDispatcherServicesWithJobPersistenceComponents,
-            @Nonnull JobManagerRunnerFactory jobManagerRunnerFactory) {
+            PartialDispatcherServicesWithJobPersistenceComponents
+                    partialDispatcherServicesWithJobPersistenceComponents,
+            JobManagerRunnerFactory jobManagerRunnerFactory) {
         return new DispatcherServices(
                 partialDispatcherServicesWithJobPersistenceComponents.getConfiguration(),
                 partialDispatcherServicesWithJobPersistenceComponents.getHighAvailabilityServices(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
@@ -60,6 +61,8 @@ public class DispatcherServices {
 
     private final JobGraphWriter jobGraphWriter;
 
+    private final JobResultStore jobResultStore;
+
     private final JobManagerRunnerFactory jobManagerRunnerFactory;
 
     private final Executor ioExecutor;
@@ -77,6 +80,7 @@ public class DispatcherServices {
             DispatcherOperationCaches operationCaches,
             JobManagerMetricGroup jobManagerMetricGroup,
             JobGraphWriter jobGraphWriter,
+            JobResultStore jobResultStore,
             JobManagerRunnerFactory jobManagerRunnerFactory,
             Executor ioExecutor) {
         this.configuration = Preconditions.checkNotNull(configuration, "Configuration");
@@ -97,6 +101,7 @@ public class DispatcherServices {
         this.jobManagerMetricGroup =
                 Preconditions.checkNotNull(jobManagerMetricGroup, "JobManagerMetricGroup");
         this.jobGraphWriter = Preconditions.checkNotNull(jobGraphWriter, "JobGraphWriter");
+        this.jobResultStore = Preconditions.checkNotNull(jobResultStore, "JobResultStore");
         this.jobManagerRunnerFactory =
                 Preconditions.checkNotNull(jobManagerRunnerFactory, "JobManagerRunnerFactory");
         this.ioExecutor = Preconditions.checkNotNull(ioExecutor, "IOExecutor");
@@ -151,6 +156,10 @@ public class DispatcherServices {
         return jobGraphWriter;
     }
 
+    public JobResultStore getJobResultStore() {
+        return jobResultStore;
+    }
+
     JobManagerRunnerFactory getJobManagerRunnerFactory() {
         return jobManagerRunnerFactory;
     }
@@ -181,6 +190,7 @@ public class DispatcherServices {
                         .getJobManagerMetricGroupFactory()
                         .create(),
                 partialDispatcherServicesWithJobPersistenceComponents.getJobGraphWriter(),
+                partialDispatcherServicesWithJobPersistenceComponents.getJobResultStore(),
                 jobManagerRunnerFactory,
                 partialDispatcherServicesWithJobPersistenceComponents.getIoExecutor());
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
@@ -167,25 +167,28 @@ public class DispatcherServices {
 
     public static DispatcherServices from(
             @Nonnull
-                    PartialDispatcherServicesWithJobGraphStore
-                            partialDispatcherServicesWithJobGraphStore,
+                    PartialDispatcherServicesWithJobPersistenceComponents
+                            partialDispatcherServicesWithJobPersistenceComponents,
             @Nonnull JobManagerRunnerFactory jobManagerRunnerFactory) {
         return new DispatcherServices(
-                partialDispatcherServicesWithJobGraphStore.getConfiguration(),
-                partialDispatcherServicesWithJobGraphStore.getHighAvailabilityServices(),
-                partialDispatcherServicesWithJobGraphStore.getResourceManagerGatewayRetriever(),
-                partialDispatcherServicesWithJobGraphStore.getBlobServer(),
-                partialDispatcherServicesWithJobGraphStore.getHeartbeatServices(),
-                partialDispatcherServicesWithJobGraphStore.getArchivedExecutionGraphStore(),
-                partialDispatcherServicesWithJobGraphStore.getFatalErrorHandler(),
-                partialDispatcherServicesWithJobGraphStore.getHistoryServerArchivist(),
-                partialDispatcherServicesWithJobGraphStore.getMetricQueryServiceAddress(),
-                partialDispatcherServicesWithJobGraphStore.getOperationCaches(),
-                partialDispatcherServicesWithJobGraphStore
+                partialDispatcherServicesWithJobPersistenceComponents.getConfiguration(),
+                partialDispatcherServicesWithJobPersistenceComponents.getHighAvailabilityServices(),
+                partialDispatcherServicesWithJobPersistenceComponents
+                        .getResourceManagerGatewayRetriever(),
+                partialDispatcherServicesWithJobPersistenceComponents.getBlobServer(),
+                partialDispatcherServicesWithJobPersistenceComponents.getHeartbeatServices(),
+                partialDispatcherServicesWithJobPersistenceComponents
+                        .getArchivedExecutionGraphStore(),
+                partialDispatcherServicesWithJobPersistenceComponents.getFatalErrorHandler(),
+                partialDispatcherServicesWithJobPersistenceComponents.getHistoryServerArchivist(),
+                partialDispatcherServicesWithJobPersistenceComponents
+                        .getMetricQueryServiceAddress(),
+                partialDispatcherServicesWithJobPersistenceComponents.getOperationCaches(),
+                partialDispatcherServicesWithJobPersistenceComponents
                         .getJobManagerMetricGroupFactory()
                         .create(),
-                partialDispatcherServicesWithJobGraphStore.getJobGraphWriter(),
+                partialDispatcherServicesWithJobPersistenceComponents.getJobGraphWriter(),
                 jobManagerRunnerFactory,
-                partialDispatcherServicesWithJobGraphStore.getIoExecutor());
+                partialDispatcherServicesWithJobPersistenceComponents.getIoExecutor());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
@@ -41,12 +41,13 @@ public enum JobDispatcherFactory implements DispatcherFactory {
             Collection<JobGraph> recoveredJobs,
             Collection<JobResult> globallyTerminatedJobs,
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
-            PartialDispatcherServicesWithJobGraphStore partialDispatcherServicesWithJobGraphStore)
+            PartialDispatcherServicesWithJobPersistenceComponents
+                    partialDispatcherServicesWithJobPersistenceComponents)
             throws Exception {
         final JobGraph jobGraph = Iterables.getOnlyElement(recoveredJobs);
 
         final Configuration configuration =
-                partialDispatcherServicesWithJobGraphStore.getConfiguration();
+                partialDispatcherServicesWithJobPersistenceComponents.getConfiguration();
         final String executionModeValue = configuration.getString(INTERNAL_CLUSTER_EXECUTION_MODE);
         final ClusterEntrypoint.ExecutionMode executionMode =
                 ClusterEntrypoint.ExecutionMode.valueOf(executionModeValue);
@@ -55,7 +56,7 @@ public enum JobDispatcherFactory implements DispatcherFactory {
                 rpcService,
                 fencingToken,
                 DispatcherServices.from(
-                        partialDispatcherServicesWithJobGraphStore,
+                        partialDispatcherServicesWithJobPersistenceComponents,
                         JobMasterServiceLeadershipRunnerFactory.INSTANCE),
                 jobGraph,
                 dispatcherBootstrapFactory,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.dispatcher;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rpc.RpcService;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
@@ -38,6 +39,7 @@ public enum JobDispatcherFactory implements DispatcherFactory {
             RpcService rpcService,
             DispatcherId fencingToken,
             Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> globallyTerminatedJobs,
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
             PartialDispatcherServicesWithJobGraphStore partialDispatcherServicesWithJobGraphStore)
             throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
@@ -63,6 +63,7 @@ public class MiniDispatcher extends Dispatcher {
                 rpcService,
                 fencingToken,
                 Collections.singleton(jobGraph),
+                Collections.emptyList(),
                 dispatcherBootstrapFactory,
                 dispatcherServices);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/PartialDispatcherServicesWithJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/PartialDispatcherServicesWithJobGraphStore.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -36,6 +37,7 @@ import java.util.concurrent.Executor;
 public class PartialDispatcherServicesWithJobGraphStore extends PartialDispatcherServices {
 
     @Nonnull private final JobGraphWriter jobGraphWriter;
+    private final JobResultStore jobResultStore;
 
     private PartialDispatcherServicesWithJobGraphStore(
             @Nonnull Configuration configuration,
@@ -50,7 +52,8 @@ public class PartialDispatcherServicesWithJobGraphStore extends PartialDispatche
             @Nullable String metricQueryServiceAddress,
             @Nonnull Executor ioExecutor,
             @Nonnull DispatcherOperationCaches operationCaches,
-            @Nonnull JobGraphWriter jobGraphWriter) {
+            @Nonnull JobGraphWriter jobGraphWriter,
+            @Nonnull JobResultStore jobResultStore) {
         super(
                 configuration,
                 highAvailabilityServices,
@@ -65,6 +68,7 @@ public class PartialDispatcherServicesWithJobGraphStore extends PartialDispatche
                 ioExecutor,
                 operationCaches);
         this.jobGraphWriter = jobGraphWriter;
+        this.jobResultStore = jobResultStore;
     }
 
     @Nonnull
@@ -72,8 +76,14 @@ public class PartialDispatcherServicesWithJobGraphStore extends PartialDispatche
         return jobGraphWriter;
     }
 
+    public JobResultStore getJobResultStore() {
+        return jobResultStore;
+    }
+
     public static PartialDispatcherServicesWithJobGraphStore from(
-            PartialDispatcherServices partialDispatcherServices, JobGraphWriter jobGraphWriter) {
+            PartialDispatcherServices partialDispatcherServices,
+            JobGraphWriter jobGraphWriter,
+            JobResultStore jobResultStore) {
         return new PartialDispatcherServicesWithJobGraphStore(
                 partialDispatcherServices.getConfiguration(),
                 partialDispatcherServices.getHighAvailabilityServices(),
@@ -87,6 +97,7 @@ public class PartialDispatcherServicesWithJobGraphStore extends PartialDispatche
                 partialDispatcherServices.getMetricQueryServiceAddress(),
                 partialDispatcherServices.getIoExecutor(),
                 partialDispatcherServices.getOperationCaches(),
-                jobGraphWriter);
+                jobGraphWriter,
+                jobResultStore);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/PartialDispatcherServicesWithJobPersistenceComponents.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/PartialDispatcherServicesWithJobPersistenceComponents.java
@@ -34,12 +34,13 @@ import javax.annotation.Nullable;
 import java.util.concurrent.Executor;
 
 /** {@link DispatcherFactory} services container. */
-public class PartialDispatcherServicesWithJobGraphStore extends PartialDispatcherServices {
+public class PartialDispatcherServicesWithJobPersistenceComponents
+        extends PartialDispatcherServices {
 
     @Nonnull private final JobGraphWriter jobGraphWriter;
     private final JobResultStore jobResultStore;
 
-    private PartialDispatcherServicesWithJobGraphStore(
+    private PartialDispatcherServicesWithJobPersistenceComponents(
             @Nonnull Configuration configuration,
             @Nonnull HighAvailabilityServices highAvailabilityServices,
             @Nonnull GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
@@ -80,11 +81,11 @@ public class PartialDispatcherServicesWithJobGraphStore extends PartialDispatche
         return jobResultStore;
     }
 
-    public static PartialDispatcherServicesWithJobGraphStore from(
+    public static PartialDispatcherServicesWithJobPersistenceComponents from(
             PartialDispatcherServices partialDispatcherServices,
             JobGraphWriter jobGraphWriter,
             JobResultStore jobResultStore) {
-        return new PartialDispatcherServicesWithJobGraphStore(
+        return new PartialDispatcherServicesWithJobPersistenceComponents(
                 partialDispatcherServices.getConfiguration(),
                 partialDispatcherServices.getHighAvailabilityServices(),
                 partialDispatcherServices.getResourceManagerGatewayRetriever(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/PartialDispatcherServicesWithJobPersistenceComponents.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/PartialDispatcherServicesWithJobPersistenceComponents.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.concurrent.Executor;
@@ -37,24 +36,24 @@ import java.util.concurrent.Executor;
 public class PartialDispatcherServicesWithJobPersistenceComponents
         extends PartialDispatcherServices {
 
-    @Nonnull private final JobGraphWriter jobGraphWriter;
+    private final JobGraphWriter jobGraphWriter;
     private final JobResultStore jobResultStore;
 
     private PartialDispatcherServicesWithJobPersistenceComponents(
-            @Nonnull Configuration configuration,
-            @Nonnull HighAvailabilityServices highAvailabilityServices,
-            @Nonnull GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
-            @Nonnull BlobServer blobServer,
-            @Nonnull HeartbeatServices heartbeatServices,
-            @Nonnull JobManagerMetricGroupFactory jobManagerMetricGroupFactory,
-            @Nonnull ExecutionGraphInfoStore executionGraphInfoStore,
-            @Nonnull FatalErrorHandler fatalErrorHandler,
-            @Nonnull HistoryServerArchivist historyServerArchivist,
+            Configuration configuration,
+            HighAvailabilityServices highAvailabilityServices,
+            GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
+            BlobServer blobServer,
+            HeartbeatServices heartbeatServices,
+            JobManagerMetricGroupFactory jobManagerMetricGroupFactory,
+            ExecutionGraphInfoStore executionGraphInfoStore,
+            FatalErrorHandler fatalErrorHandler,
+            HistoryServerArchivist historyServerArchivist,
             @Nullable String metricQueryServiceAddress,
-            @Nonnull Executor ioExecutor,
-            @Nonnull DispatcherOperationCaches operationCaches,
-            @Nonnull JobGraphWriter jobGraphWriter,
-            @Nonnull JobResultStore jobResultStore) {
+            Executor ioExecutor,
+            DispatcherOperationCaches operationCaches,
+            JobGraphWriter jobGraphWriter,
+            JobResultStore jobResultStore) {
         super(
                 configuration,
                 highAvailabilityServices,
@@ -72,7 +71,6 @@ public class PartialDispatcherServicesWithJobPersistenceComponents
         this.jobResultStore = jobResultStore;
     }
 
-    @Nonnull
     public JobGraphWriter getJobGraphWriter() {
         return jobGraphWriter;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
@@ -43,6 +43,7 @@ public enum SessionDispatcherFactory implements DispatcherFactory {
                 rpcService,
                 fencingToken,
                 recoveredJobs,
+                globallyTerminatedJobs,
                 dispatcherBootstrapFactory,
                 DispatcherServices.from(
                         partialDispatcherServicesWithJobPersistenceComponents,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
@@ -35,7 +35,8 @@ public enum SessionDispatcherFactory implements DispatcherFactory {
             Collection<JobGraph> recoveredJobs,
             Collection<JobResult> globallyTerminatedJobs,
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
-            PartialDispatcherServicesWithJobGraphStore partialDispatcherServicesWithJobGraphStore)
+            PartialDispatcherServicesWithJobPersistenceComponents
+                    partialDispatcherServicesWithJobPersistenceComponents)
             throws Exception {
         // create the default dispatcher
         return new StandaloneDispatcher(
@@ -44,7 +45,7 @@ public enum SessionDispatcherFactory implements DispatcherFactory {
                 recoveredJobs,
                 dispatcherBootstrapFactory,
                 DispatcherServices.from(
-                        partialDispatcherServicesWithJobGraphStore,
+                        partialDispatcherServicesWithJobPersistenceComponents,
                         JobMasterServiceLeadershipRunnerFactory.INSTANCE));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rpc.RpcService;
 
 import java.util.Collection;
@@ -32,6 +33,7 @@ public enum SessionDispatcherFactory implements DispatcherFactory {
             RpcService rpcService,
             DispatcherId fencingToken,
             Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> globallyTerminatedJobs,
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
             PartialDispatcherServicesWithJobGraphStore partialDispatcherServicesWithJobGraphStore)
             throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rpc.RpcService;
 
 import java.util.Collection;
@@ -34,6 +35,7 @@ public class StandaloneDispatcher extends Dispatcher {
             RpcService rpcService,
             DispatcherId fencingToken,
             Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> globallyTerminatedJobs,
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
             DispatcherServices dispatcherServices)
             throws Exception {
@@ -41,6 +43,7 @@ public class StandaloneDispatcher extends Dispatcher {
                 rpcService,
                 fencingToken,
                 recoveredJobs,
+                globallyTerminatedJobs,
                 dispatcherBootstrapFactory,
                 dispatcherServices);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/AbstractDispatcherLeaderProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/AbstractDispatcherLeaderProcess.java
@@ -24,8 +24,10 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.dispatcher.DispatcherId;
+import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphWriter;
+import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.util.AutoCloseableAsync;
@@ -176,16 +178,14 @@ public abstract class AbstractDispatcherLeaderProcess implements DispatcherLeade
         createdDispatcherService
                 .getTerminationFuture()
                 .whenComplete(
-                        (ignored, throwable) -> {
-                            runIfStateIs(
-                                    State.RUNNING,
-                                    () -> {
-                                        handleError(
-                                                new FlinkException(
-                                                        "Unexpected termination of DispatcherService.",
-                                                        throwable));
-                                    });
-                        });
+                        (ignored, throwable) ->
+                                runIfStateIs(
+                                        State.RUNNING,
+                                        () ->
+                                                handleError(
+                                                        new FlinkException(
+                                                                "Unexpected termination of DispatcherService.",
+                                                                throwable))));
     }
 
     final <V> Optional<V> supplyUnsynchronizedIfRunning(Supplier<V> supplier) {
@@ -259,7 +259,9 @@ public abstract class AbstractDispatcherLeaderProcess implements DispatcherLeade
         DispatcherGatewayService create(
                 DispatcherId fencingToken,
                 Collection<JobGraph> recoveredJobs,
-                JobGraphWriter jobGraphWriter);
+                Collection<JobResult> globallyTerminatedJobs,
+                JobGraphWriter jobGraphWriter,
+                JobResultStore jobResultStore);
     }
 
     /** An accessor of the {@link DispatcherGateway}. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherGatewayServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherGatewayServiceFactory.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.dispatcher.DispatcherFactory;
 import org.apache.flink.runtime.dispatcher.DispatcherId;
 import org.apache.flink.runtime.dispatcher.NoOpDispatcherBootstrap;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
-import org.apache.flink.runtime.dispatcher.PartialDispatcherServicesWithJobGraphStore;
+import org.apache.flink.runtime.dispatcher.PartialDispatcherServicesWithJobPersistenceComponents;
 import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphWriter;
@@ -70,7 +70,7 @@ class DefaultDispatcherGatewayServiceFactory
                             globallyTerminatedJobs,
                             (dispatcherGateway, scheduledExecutor, errorHandler) ->
                                     new NoOpDispatcherBootstrap(),
-                            PartialDispatcherServicesWithJobGraphStore.from(
+                            PartialDispatcherServicesWithJobPersistenceComponents.from(
                                     partialDispatcherServices, jobGraphWriter, jobResultStore));
         } catch (Exception e) {
             throw new FlinkRuntimeException("Could not create the Dispatcher rpc endpoint.", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherGatewayServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherGatewayServiceFactory.java
@@ -24,8 +24,10 @@ import org.apache.flink.runtime.dispatcher.DispatcherId;
 import org.apache.flink.runtime.dispatcher.NoOpDispatcherBootstrap;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServicesWithJobGraphStore;
+import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphWriter;
+import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -54,7 +56,9 @@ class DefaultDispatcherGatewayServiceFactory
     public AbstractDispatcherLeaderProcess.DispatcherGatewayService create(
             DispatcherId fencingToken,
             Collection<JobGraph> recoveredJobs,
-            JobGraphWriter jobGraphWriter) {
+            Collection<JobResult> globallyTerminatedJobs,
+            JobGraphWriter jobGraphWriter,
+            JobResultStore jobResultStore) {
 
         final Dispatcher dispatcher;
         try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherGatewayServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherGatewayServiceFactory.java
@@ -67,10 +67,11 @@ class DefaultDispatcherGatewayServiceFactory
                             rpcService,
                             fencingToken,
                             recoveredJobs,
+                            globallyTerminatedJobs,
                             (dispatcherGateway, scheduledExecutor, errorHandler) ->
                                     new NoOpDispatcherBootstrap(),
                             PartialDispatcherServicesWithJobGraphStore.from(
-                                    partialDispatcherServices, jobGraphWriter));
+                                    partialDispatcherServices, jobGraphWriter, jobResultStore));
         } catch (Exception e) {
             throw new FlinkRuntimeException("Could not create the Dispatcher rpc endpoint.", e);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerFactory.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.dispatcher.runner;
 import org.apache.flink.runtime.dispatcher.DispatcherFactory;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
 import org.apache.flink.runtime.entrypoint.component.JobGraphRetriever;
-import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
+import org.apache.flink.runtime.jobmanager.JobPersistenceComponentFactory;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -44,7 +44,7 @@ public class DefaultDispatcherRunnerFactory implements DispatcherRunnerFactory {
     public DispatcherRunner createDispatcherRunner(
             LeaderElectionService leaderElectionService,
             FatalErrorHandler fatalErrorHandler,
-            JobGraphStoreFactory jobGraphStoreFactory,
+            JobPersistenceComponentFactory jobPersistenceComponentFactory,
             Executor ioExecutor,
             RpcService rpcService,
             PartialDispatcherServices partialDispatcherServices)
@@ -52,7 +52,7 @@ public class DefaultDispatcherRunnerFactory implements DispatcherRunnerFactory {
 
         final DispatcherLeaderProcessFactory dispatcherLeaderProcessFactory =
                 dispatcherLeaderProcessFactoryFactory.createFactory(
-                        jobGraphStoreFactory,
+                        jobPersistenceComponentFactory,
                         ioExecutor,
                         rpcService,
                         partialDispatcherServices,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherLeaderProcessFactoryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherLeaderProcessFactoryFactory.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.dispatcher.runner;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
-import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
+import org.apache.flink.runtime.jobmanager.JobPersistenceComponentFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 
@@ -31,7 +31,7 @@ import java.util.concurrent.Executor;
 public interface DispatcherLeaderProcessFactoryFactory {
 
     DispatcherLeaderProcessFactory createFactory(
-            JobGraphStoreFactory jobGraphStoreFactory,
+            JobPersistenceComponentFactory jobPersistenceComponentFactory,
             Executor ioExecutor,
             RpcService rpcService,
             PartialDispatcherServices partialDispatcherServices,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherRunnerFactory.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.dispatcher.runner;
 
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
-import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
+import org.apache.flink.runtime.jobmanager.JobPersistenceComponentFactory;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -32,7 +32,7 @@ public interface DispatcherRunnerFactory {
     DispatcherRunner createDispatcherRunner(
             LeaderElectionService leaderElectionService,
             FatalErrorHandler fatalErrorHandler,
-            JobGraphStoreFactory jobGraphStoreFactory,
+            JobPersistenceComponentFactory jobPersistenceComponentFactory,
             Executor ioExecutor,
             RpcService rpcService,
             PartialDispatcherServices partialDispatcherServices)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/JobDispatcherLeaderProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/JobDispatcherLeaderProcess.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.dispatcher.runner;
 
 import org.apache.flink.runtime.dispatcher.DispatcherId;
+import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.ThrowingJobGraphWriter;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -49,7 +50,9 @@ public class JobDispatcherLeaderProcess extends AbstractDispatcherLeaderProcess 
                 dispatcherGatewayServiceFactory.create(
                         DispatcherId.fromUuid(getLeaderSessionId()),
                         Collections.singleton(jobGraph),
-                        ThrowingJobGraphWriter.INSTANCE);
+                        Collections.emptyList(),
+                        ThrowingJobGraphWriter.INSTANCE,
+                        new EmbeddedJobResultStore());
 
         completeDispatcherSetup(dispatcherService);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/JobDispatcherLeaderProcessFactoryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/JobDispatcherLeaderProcessFactoryFactory.java
@@ -22,7 +22,7 @@ import org.apache.flink.runtime.dispatcher.JobDispatcherFactory;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
 import org.apache.flink.runtime.entrypoint.component.JobGraphRetriever;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
+import org.apache.flink.runtime.jobmanager.JobPersistenceComponentFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.util.FlinkException;
@@ -42,7 +42,7 @@ public class JobDispatcherLeaderProcessFactoryFactory
 
     @Override
     public DispatcherLeaderProcessFactory createFactory(
-            JobGraphStoreFactory jobGraphStoreFactory,
+            JobPersistenceComponentFactory jobPersistenceComponentFactory,
             Executor ioExecutor,
             RpcService rpcService,
             PartialDispatcherServices partialDispatcherServices,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcess.java
@@ -109,7 +109,11 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
 
         final DispatcherGatewayService dispatcherService =
                 dispatcherGatewayServiceFactory.create(
-                        DispatcherId.fromUuid(getLeaderSessionId()), jobGraphs, jobGraphStore);
+                        DispatcherId.fromUuid(getLeaderSessionId()),
+                        jobGraphs,
+                        globallyTerminatedJobs,
+                        jobGraphStore,
+                        jobResultStore);
 
         completeDispatcherSetup(dispatcherService);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcess.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.dispatcher.DispatcherId;
+import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -53,6 +54,8 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
 
     private final JobGraphStore jobGraphStore;
 
+    private final JobResultStore jobResultStore;
+
     private final Executor ioExecutor;
 
     private CompletableFuture<Void> onGoingRecoveryOperation = FutureUtils.completedVoidFuture();
@@ -61,12 +64,14 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
             UUID leaderSessionId,
             DispatcherGatewayServiceFactory dispatcherGatewayServiceFactory,
             JobGraphStore jobGraphStore,
+            JobResultStore jobResultStore,
             Executor ioExecutor,
             FatalErrorHandler fatalErrorHandler) {
         super(leaderSessionId, fatalErrorHandler);
 
         this.dispatcherGatewayServiceFactory = dispatcherGatewayServiceFactory;
         this.jobGraphStore = jobGraphStore;
+        this.jobResultStore = jobResultStore;
         this.ioExecutor = ioExecutor;
     }
 
@@ -261,9 +266,15 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
             UUID leaderSessionId,
             DispatcherGatewayServiceFactory dispatcherFactory,
             JobGraphStore jobGraphStore,
+            JobResultStore jobResultStore,
             Executor ioExecutor,
             FatalErrorHandler fatalErrorHandler) {
         return new SessionDispatcherLeaderProcess(
-                leaderSessionId, dispatcherFactory, jobGraphStore, ioExecutor, fatalErrorHandler);
+                leaderSessionId,
+                dispatcherFactory,
+                jobGraphStore,
+                jobResultStore,
+                ioExecutor,
+                fatalErrorHandler);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessFactory.java
@@ -53,6 +53,7 @@ public class SessionDispatcherLeaderProcessFactory implements DispatcherLeaderPr
                 leaderSessionID,
                 dispatcherGatewayServiceFactory,
                 jobPersistenceComponentFactory.createJobGraphStore(),
+                jobPersistenceComponentFactory.createJobResultStore(),
                 ioExecutor,
                 fatalErrorHandler);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessFactory.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.dispatcher.runner;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
+import org.apache.flink.runtime.jobmanager.JobPersistenceComponentFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 
 import java.util.UUID;
@@ -31,18 +31,18 @@ public class SessionDispatcherLeaderProcessFactory implements DispatcherLeaderPr
 
     private final AbstractDispatcherLeaderProcess.DispatcherGatewayServiceFactory
             dispatcherGatewayServiceFactory;
-    private final JobGraphStoreFactory jobGraphStoreFactory;
+    private final JobPersistenceComponentFactory jobPersistenceComponentFactory;
     private final Executor ioExecutor;
     private final FatalErrorHandler fatalErrorHandler;
 
     public SessionDispatcherLeaderProcessFactory(
             AbstractDispatcherLeaderProcess.DispatcherGatewayServiceFactory
                     dispatcherGatewayServiceFactory,
-            JobGraphStoreFactory jobGraphStoreFactory,
+            JobPersistenceComponentFactory jobPersistenceComponentFactory,
             Executor ioExecutor,
             FatalErrorHandler fatalErrorHandler) {
         this.dispatcherGatewayServiceFactory = dispatcherGatewayServiceFactory;
-        this.jobGraphStoreFactory = jobGraphStoreFactory;
+        this.jobPersistenceComponentFactory = jobPersistenceComponentFactory;
         this.ioExecutor = ioExecutor;
         this.fatalErrorHandler = fatalErrorHandler;
     }
@@ -52,7 +52,7 @@ public class SessionDispatcherLeaderProcessFactory implements DispatcherLeaderPr
         return SessionDispatcherLeaderProcess.create(
                 leaderSessionID,
                 dispatcherGatewayServiceFactory,
-                jobGraphStoreFactory.create(),
+                jobPersistenceComponentFactory.createJobGraphStore(),
                 ioExecutor,
                 fatalErrorHandler);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessFactoryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessFactoryFactory.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.dispatcher.runner;
 
 import org.apache.flink.runtime.dispatcher.DispatcherFactory;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
-import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
+import org.apache.flink.runtime.jobmanager.JobPersistenceComponentFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 
@@ -38,7 +38,7 @@ public class SessionDispatcherLeaderProcessFactoryFactory
 
     @Override
     public DispatcherLeaderProcessFactory createFactory(
-            JobGraphStoreFactory jobGraphStoreFactory,
+            JobPersistenceComponentFactory jobPersistenceComponentFactory,
             Executor ioExecutor,
             RpcService rpcService,
             PartialDispatcherServices partialDispatcherServices,
@@ -50,7 +50,7 @@ public class SessionDispatcherLeaderProcessFactoryFactory
 
         return new SessionDispatcherLeaderProcessFactory(
                 dispatcherGatewayServiceFactory,
-                jobGraphStoreFactory,
+                jobPersistenceComponentFactory,
                 ioExecutor,
                 fatalErrorHandler);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
@@ -35,7 +35,7 @@ import org.apache.flink.runtime.dispatcher.runner.DispatcherRunnerFactory;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.jobmanager.HaServicesJobGraphStoreFactory;
+import org.apache.flink.runtime.jobmanager.HaServicesJobPersistenceComponentFactory;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
@@ -218,7 +218,7 @@ public class DefaultDispatcherResourceManagerComponentFactory
                     dispatcherRunnerFactory.createDispatcherRunner(
                             highAvailabilityServices.getDispatcherLeaderElectionService(),
                             fatalErrorHandler,
-                            new HaServicesJobGraphStoreFactory(highAvailabilityServices),
+                            new HaServicesJobPersistenceComponentFactory(highAvailabilityServices),
                             ioExecutor,
                             rpcService,
                             partialDispatcherServices);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/HaServicesJobPersistenceComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/HaServicesJobPersistenceComponentFactory.java
@@ -22,18 +22,19 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.util.FlinkRuntimeException;
 
 /**
- * {@link JobGraphStoreFactory} implementation which creates a {@link JobGraphStore} using the
- * provided {@link HighAvailabilityServices}.
+ * {@link JobPersistenceComponentFactory} implementation which creates a {@link JobGraphStore} using
+ * the provided {@link HighAvailabilityServices}.
  */
-public class HaServicesJobGraphStoreFactory implements JobGraphStoreFactory {
+public class HaServicesJobPersistenceComponentFactory implements JobPersistenceComponentFactory {
     private final HighAvailabilityServices highAvailabilityServices;
 
-    public HaServicesJobGraphStoreFactory(HighAvailabilityServices highAvailabilityServices) {
+    public HaServicesJobPersistenceComponentFactory(
+            HighAvailabilityServices highAvailabilityServices) {
         this.highAvailabilityServices = highAvailabilityServices;
     }
 
     @Override
-    public JobGraphStore create() {
+    public JobGraphStore createJobGraphStore() {
         try {
             return highAvailabilityServices.getJobGraphStore();
         } catch (Exception e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobPersistenceComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobPersistenceComponentFactory.java
@@ -19,12 +19,12 @@
 package org.apache.flink.runtime.jobmanager;
 
 /** Factory for {@link JobGraphStore}. */
-public interface JobGraphStoreFactory {
+public interface JobPersistenceComponentFactory {
 
     /**
      * Creates a {@link JobGraphStore}.
      *
      * @return a {@link JobGraphStore} instance
      */
-    JobGraphStore create();
+    JobGraphStore createJobGraphStore();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobPersistenceComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobPersistenceComponentFactory.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.runtime.jobmanager;
 
-/** Factory for {@link JobGraphStore}. */
+import org.apache.flink.runtime.highavailability.JobResultStore;
+
+/** Factory for components that are responsible for persisting a job for recovery. */
 public interface JobPersistenceComponentFactory {
 
     /**
@@ -27,4 +29,11 @@ public interface JobPersistenceComponentFactory {
      * @return a {@link JobGraphStore} instance
      */
     JobGraphStore createJobGraphStore();
+
+    /**
+     * Creates {@link JobResultStore} instances.
+     *
+     * @return {@code JobResultStore} instances.
+     */
+    JobResultStore createJobResultStore();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -197,6 +197,7 @@ public class AbstractDispatcherTest extends TestLogger {
                     rpcService,
                     DispatcherId.generate(),
                     initialJobGraphs,
+                    Collections.emptyList(),
                     dispatcherBootstrapFactory,
                     new DispatcherServices(
                             configuration,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphWriter;
@@ -144,6 +145,8 @@ public class AbstractDispatcherTest extends TestLogger {
 
         private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
 
+        private JobResultStore jobResultStore = TestingJobResultStore.builder().build();
+
         private FatalErrorHandler fatalErrorHandler =
                 testingFatalErrorHandlerResource.getFatalErrorHandler();
 
@@ -170,6 +173,11 @@ public class AbstractDispatcherTest extends TestLogger {
 
         TestingDispatcherBuilder setJobGraphWriter(JobGraphWriter jobGraphWriter) {
             this.jobGraphWriter = jobGraphWriter;
+            return this;
+        }
+
+        TestingDispatcherBuilder setJobResultStore(JobResultStore jobResultStore) {
+            this.jobResultStore = jobResultStore;
             return this;
         }
 
@@ -203,6 +211,7 @@ public class AbstractDispatcherTest extends TestLogger {
                             new DispatcherOperationCaches(),
                             UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
                             jobGraphWriter,
+                            jobResultStore,
                             jobManagerRunnerFactory,
                             ForkJoinPool.commonPool()));
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -208,6 +208,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                         rpcService,
                         DispatcherId.generate(),
                         Collections.emptyList(),
+                        Collections.emptyList(),
                         (dispatcher, scheduledExecutor, errorHandler) ->
                                 new NoOpDispatcherBootstrap(),
                         new DispatcherServices(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -223,6 +223,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                                 new DispatcherOperationCaches(),
                                 UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
                                 jobGraphWriter,
+                                jobResultStore,
                                 jobManagerRunnerFactory,
                                 ForkJoinPool.commonPool()));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -266,6 +266,7 @@ public class MiniDispatcherTest extends TestLogger {
                         new DispatcherOperationCaches(),
                         UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
                         highAvailabilityServices.getJobGraphStore(),
+                        highAvailabilityServices.getJobResultStore(),
                         testingJobManagerRunnerFactory,
                         ForkJoinPool.commonPool()),
                 jobGraph,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.dispatcher;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 
@@ -39,6 +40,7 @@ class TestingDispatcher extends Dispatcher {
             RpcService rpcService,
             DispatcherId fencingToken,
             Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> globallyTerminatedJobs,
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
             DispatcherServices dispatcherServices)
             throws Exception {
@@ -46,6 +48,7 @@ class TestingDispatcher extends Dispatcher {
                 rpcService,
                 fencingToken,
                 recoveredJobs,
+                globallyTerminatedJobs,
                 dispatcherBootstrapFactory,
                 dispatcherServices);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.dispatcher.DispatcherServices;
 import org.apache.flink.runtime.dispatcher.JobManagerRunnerFactory;
 import org.apache.flink.runtime.dispatcher.MemoryExecutionGraphInfoStore;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
-import org.apache.flink.runtime.dispatcher.PartialDispatcherServicesWithJobGraphStore;
+import org.apache.flink.runtime.dispatcher.PartialDispatcherServicesWithJobPersistenceComponents;
 import org.apache.flink.runtime.dispatcher.SessionDispatcherFactory;
 import org.apache.flink.runtime.dispatcher.SingleJobJobGraphStore;
 import org.apache.flink.runtime.dispatcher.StandaloneDispatcher;
@@ -249,8 +249,8 @@ public class DefaultDispatcherRunnerITCase extends TestLogger {
                 Collection<JobGraph> recoveredJobs,
                 Collection<JobResult> globallyTerminatedJobs,
                 DispatcherBootstrapFactory dispatcherBootstrapFactory,
-                PartialDispatcherServicesWithJobGraphStore
-                        partialDispatcherServicesWithJobGraphStore)
+                PartialDispatcherServicesWithJobPersistenceComponents
+                        partialDispatcherServicesWithJobPersistenceComponents)
                 throws Exception {
             return new StandaloneDispatcher(
                     rpcService,
@@ -258,7 +258,8 @@ public class DefaultDispatcherRunnerITCase extends TestLogger {
                     recoveredJobs,
                     dispatcherBootstrapFactory,
                     DispatcherServices.from(
-                            partialDispatcherServicesWithJobGraphStore, jobManagerRunnerFactory));
+                            partialDispatcherServicesWithJobPersistenceComponents,
+                            jobManagerRunnerFactory));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
@@ -256,6 +256,7 @@ public class DefaultDispatcherRunnerITCase extends TestLogger {
                     rpcService,
                     fencingToken,
                     recoveredJobs,
+                    globallyTerminatedJobs,
                     dispatcherBootstrapFactory,
                     DispatcherServices.from(
                             partialDispatcherServicesWithJobPersistenceComponents,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
 import org.apache.flink.runtime.jobmanager.JobPersistenceComponentFactory;
+import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
@@ -246,6 +247,7 @@ public class DefaultDispatcherRunnerITCase extends TestLogger {
                 RpcService rpcService,
                 DispatcherId fencingToken,
                 Collection<JobGraph> recoveredJobs,
+                Collection<JobResult> globallyTerminatedJobs,
                 DispatcherBootstrapFactory dispatcherBootstrapFactory,
                 PartialDispatcherServicesWithJobGraphStore
                         partialDispatcherServicesWithJobGraphStore)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
@@ -22,11 +22,13 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
 import org.apache.flink.runtime.client.JobSubmissionException;
+import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.testutils.TestingJobGraphStore;
+import org.apache.flink.runtime.testutils.TestingJobResultStore;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
 import org.apache.flink.util.ExceptionUtils;
@@ -73,6 +75,7 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
     private TestingFatalErrorHandler fatalErrorHandler;
 
     private JobGraphStore jobGraphStore;
+    private JobResultStore jobResultStore;
 
     private TestingDispatcherServiceFactory dispatcherServiceFactory;
 
@@ -85,6 +88,7 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
     public void setup() {
         fatalErrorHandler = new TestingFatalErrorHandler();
         jobGraphStore = TestingJobGraphStore.newBuilder().build();
+        jobResultStore = TestingJobResultStore.builder().build();
         dispatcherServiceFactory = TestingDispatcherServiceFactory.newBuilder().build();
     }
 
@@ -635,6 +639,7 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
                 leaderSessionId,
                 dispatcherServiceFactory,
                 jobGraphStore,
+                jobResultStore,
                 ioExecutor,
                 fatalErrorHandler);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
@@ -36,8 +36,8 @@ import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.function.QuintFunctionWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
-import org.apache.flink.util.function.TriFunctionWithException;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -132,7 +132,11 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
         dispatcherServiceFactory =
                 TestingDispatcherServiceFactory.newBuilder()
                         .setCreateFunction(
-                                (fencingToken, recoveredJobGraphs, jobGraphStore) -> {
+                                (fencingToken,
+                                        recoveredJobGraphs,
+                                        jobResults,
+                                        jobGraphStore,
+                                        jobResultStore) -> {
                                     recoveredJobGraphsFuture.complete(recoveredJobGraphs);
                                     return TestingDispatcherGatewayService.newBuilder().build();
                                 })
@@ -164,7 +168,7 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
         dispatcherServiceFactory =
                 TestingDispatcherServiceFactory.newBuilder()
                         .setCreateFunction(
-                                (ignoredA, ignoredB, ignoredC) ->
+                                (ignoredA, ignoredB, ignoredC, ignoredD, ignoredE) ->
                                         TestingDispatcherGatewayService.newBuilder()
                                                 .setTerminationFuture(
                                                         dispatcherServiceTerminationFuture)
@@ -200,7 +204,7 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
         dispatcherServiceFactory =
                 TestingDispatcherServiceFactory.newBuilder()
                         .setCreateFunction(
-                                (ignoredA, ignoredB, ignoredC) ->
+                                (ignoredA, ignoredB, ignoredC, ignoredD, ignoredE) ->
                                         TestingDispatcherGatewayService.newBuilder()
                                                 .setTerminationFuture(terminationFuture)
                                                 .build())
@@ -225,7 +229,7 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
         dispatcherServiceFactory =
                 TestingDispatcherServiceFactory.newBuilder()
                         .setCreateFunction(
-                                (ignoredA, ignoredB, ignoredC) ->
+                                (ignoredA, ignoredB, ignoredC, ignoredD, ignoredE) ->
                                         TestingDispatcherGatewayService.newBuilder()
                                                 .setTerminationFuture(terminationFuture)
                                                 .withManualTerminationFutureCompletion()
@@ -254,8 +258,8 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
         dispatcherServiceFactory =
                 TestingDispatcherServiceFactory.newBuilder()
                         .setCreateFunction(
-                                TriFunctionWithException.unchecked(
-                                        (ignoredA, ignoredB, ignoredC) -> {
+                                QuintFunctionWithException.unchecked(
+                                        (ignoredA, ignoredB, ignoredC, ignoredD, ignoredE) -> {
                                             createDispatcherServiceLatch.await();
                                             return TestingDispatcherGatewayService.newBuilder()
                                                     .setDispatcherGateway(dispatcherGateway)
@@ -297,7 +301,7 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
         this.dispatcherServiceFactory =
                 TestingDispatcherServiceFactory.newBuilder()
                         .setCreateFunction(
-                                (ignoredA, ignoredB, ignoredC) -> {
+                                (ignoredA, ignoredB, ignoredC, ignoredD, ignoredE) -> {
                                     createDispatcherServiceLatch.trigger();
                                     return TestingDispatcherGatewayService.newBuilder().build();
                                 })
@@ -341,8 +345,11 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
         dispatcherServiceFactory =
                 TestingDispatcherServiceFactory.newBuilder()
                         .setCreateFunction(
-                                (dispatcherId, jobGraphs, jobGraphWriter) ->
-                                        testingDispatcherService)
+                                (dispatcherId,
+                                        jobGraphs,
+                                        globallyTerminatedJobs,
+                                        jobGraphWriter,
+                                        jobResultStore) -> testingDispatcherService)
                         .build();
 
         try (final SessionDispatcherLeaderProcess dispatcherLeaderProcess =
@@ -373,8 +380,11 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
         dispatcherServiceFactory =
                 TestingDispatcherServiceFactory.newBuilder()
                         .setCreateFunction(
-                                (dispatcherId, jobGraphs, jobGraphWriter) ->
-                                        testingDispatcherService)
+                                (dispatcherId,
+                                        jobGraphs,
+                                        globallyTerminatedJobs,
+                                        jobGraphWriter,
+                                        jobResultStore) -> testingDispatcherService)
                         .build();
 
         try (final SessionDispatcherLeaderProcess dispatcherLeaderProcess =
@@ -592,7 +602,11 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
         dispatcherServiceFactory =
                 TestingDispatcherServiceFactory.newBuilder()
                         .setCreateFunction(
-                                (dispatcherId, jobGraphs, jobGraphWriter) -> {
+                                (dispatcherId,
+                                        jobGraphs,
+                                        globallyTerminatedJobs,
+                                        jobGraphWriter,
+                                        jobResultStore) -> {
                                     assertThat(jobGraphs, containsInAnyOrder(JOB_GRAPH));
 
                                     return TestingDispatcherGatewayService.newBuilder()
@@ -627,7 +641,7 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
             TestingDispatcherGateway testingDispatcherGateway) {
         return TestingDispatcherServiceFactory.newBuilder()
                 .setCreateFunction(
-                        (ignoredA, ignoredB, ignoredC) ->
+                        (ignoredA, ignoredB, ignoredC, ignoredD, ignoredE) ->
                                 TestingDispatcherGatewayService.newBuilder()
                                         .setDispatcherGateway(testingDispatcherGateway)
                                         .build())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -42,7 +42,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
-import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
+import org.apache.flink.runtime.jobmanager.JobPersistenceComponentFactory;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
@@ -226,14 +226,14 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
     private DispatcherRunner createDispatcherRunner(
             TestingRpcService rpcService,
             TestingLeaderElectionService dispatcherLeaderElectionService,
-            JobGraphStoreFactory jobGraphStoreFactory,
+            JobPersistenceComponentFactory jobPersistenceComponentFactory,
             PartialDispatcherServices partialDispatcherServices,
             DispatcherRunnerFactory dispatcherRunnerFactory)
             throws Exception {
         return dispatcherRunnerFactory.createDispatcherRunner(
                 dispatcherLeaderElectionService,
                 fatalErrorHandler,
-                jobGraphStoreFactory,
+                jobPersistenceComponentFactory,
                 TestingUtils.defaultExecutor(),
                 rpcService,
                 partialDispatcherServices);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.dispatcher.SessionDispatcherFactory;
 import org.apache.flink.runtime.dispatcher.VoidHistoryServerArchivist;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
+import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServicesBuilder;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
@@ -179,7 +180,17 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
                     createDispatcherRunner(
                             rpcService,
                             dispatcherLeaderElectionService,
-                            () -> createZooKeeperJobGraphStore(client),
+                            new JobPersistenceComponentFactory() {
+                                @Override
+                                public JobGraphStore createJobGraphStore() {
+                                    return createZooKeeperJobGraphStore(client);
+                                }
+
+                                @Override
+                                public JobResultStore createJobResultStore() {
+                                    return new EmbeddedJobResultStore();
+                                }
+                            },
                             partialDispatcherServices,
                             defaultDispatcherRunnerFactory)) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.entrypoint.component.DefaultDispatcherResourceMa
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServicesBuilder;
-import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
+import org.apache.flink.runtime.jobmanager.JobPersistenceComponentFactory;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerFactory;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
@@ -339,7 +339,7 @@ public class ClusterEntrypointTest extends TestLogger {
         public DispatcherRunner createDispatcherRunner(
                 LeaderElectionService leaderElectionService,
                 FatalErrorHandler fatalErrorHandler,
-                JobGraphStoreFactory jobGraphStoreFactory,
+                JobPersistenceComponentFactory jobPersistenceComponentFactory,
                 Executor ioExecutor,
                 RpcService rpcService,
                 PartialDispatcherServices partialDispatcherServices)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingJobGraphStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingJobGraphStore.java
@@ -141,6 +141,7 @@ public class TestingJobGraphStore implements JobGraphStore {
         return new Builder();
     }
 
+    /** {@code Builder} for creating {@code TestingJobGraphStore} instances. */
     public static class Builder {
         private ThrowingConsumer<JobGraphListener, ? extends Exception> startConsumer =
                 ignored -> {};


### PR DESCRIPTION
## What is the purpose of the change

`JobGraphStore` and `JobResultStore` are closely related. Both provide metadata in case of a Dispatcher failover. Hence, their lifecycle should match as well. The motivation is to retrieve dirty `JobResults` when retrieving `JobGraphs`. These are forwarded to the `Dispatcher`.

## Brief change log

See individual commit messages for the changes.

## Verifying this change

No explicit tests were added. `TestingJobResultStore` was introduced, though, to cover existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
